### PR TITLE
FIX: Correct unexpected t1 date assignment when look_forward=False in trend_scanning_labels

### DIFF
--- a/06 Applied Machine Learning/01 ML Trend Scanning with MLFinlab/trend_scanning_labels.py
+++ b/06 Applied Machine Learning/01 ML Trend Scanning with MLFinlab/trend_scanning_labels.py
@@ -129,7 +129,8 @@ def trend_scanning_labels(price_series: pd.Series, t_events: list = None, observ
                     max_metric_value_index = forward_window
 
             # Store label information (t1, return)
-            label_endtime_index = subset.index[max_metric_value_index - 1]
+            endtime_index = max_metric_value_index - 1 if look_forward else - max_metric_value_index
+            label_endtime_index = subset.index[endtime_index]
             t1_array.append(label_endtime_index)
             t_values_array.append(max_t_value)
 
@@ -138,7 +139,8 @@ def trend_scanning_labels(price_series: pd.Series, t_events: list = None, observ
             t_values_array.append(None)
 
     labels = pd.DataFrame({'t1': t1_array, 't_value': t_values_array}, index=t_events)
-    labels.loc[:, 'ret'] = price_series.reindex(labels.t1).values / price_series.reindex(labels.index).values - 1
+    if look_forward:
+        labels.loc[:, 'ret'] = price_series.reindex(labels.t1).values / price_series.reindex(labels.index).values - 1
     labels['bin'] = labels.t_value.apply(np.sign)
 
     return labels


### PR DESCRIPTION
### FIX: Correct unexpected `t1` date assignment when `look_forward=False` in `trend_scanning_labels`

#### Description
When `look_forward=False`, `trend_scanning_labels` assigns `t1` to an unexpected date due to incorrect indexing within the backward window.  
This indexing error causes `t1` to reference an unintended earlier timestamp.

As a result:
- The assigned `t1` label represents an **incorrect date**, not the end of the trend window.  
- Consequently, `ret` and `bin` calculations no longer follow the **intended backward trend direction**.

This PR addresses issue **#48**.

#### Affected Code
File: `06 Applied Machine Learning\01 ML Trend Scanning with MLFinlab\trend_scanning_labels.py`
```python
label_endtime_index = subset.index[max_metric_value_index - 1]
```
```python
labels.loc[:, 'ret'] = price_series.reindex(labels.t1).values / price_series.reindex(labels.index).values - 1
```

#### Proposed Fix
File: `06 Applied Machine Learning\01 ML Trend Scanning with MLFinlab\trend_scanning_labels.py`
```python
endtime_index = max_metric_value_index - 1 if look_forward else - max_metric_value_index
label_endtime_index = subset.index[endtime_index]
```
```python
if look_forward:
    labels.loc[:, 'ret'] = price_series.reindex(labels.t1).values / price_series.reindex(labels.index).values - 1
```